### PR TITLE
mimalloc: fix Visual Studio build

### DIFF
--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -10,20 +11,18 @@ class MimallocConan(ConanFile):
     description = "mimalloc is a compact general purpose allocator with excellent performance."
     topics = ("conan", "mimalloc", "allocator", "performance", "microsoft")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"fPIC": [True, False],
-               "shared": [True, False],
-               "override": [True, False]}
-    default_options = {"fPIC": True,
-                       "shared": False,
-                       "override": True}
+    options = {
+        "shared": [True, False, "object"],
+        "fPIC": [True, False],
+        "secure": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "secure": False,
+    }
     generators = "cmake"
     exports_sources = "CMakeLists.txt", "patches/*"
-    _cmake_i = None
-
-    @property
-    def _cmake_install_folder(self):
-        version = tools.Version(self.version)
-        return "{}-{}.{}".format(self.name, version.major, version.minor)
 
     @property
     def _source_subfolder(self):
@@ -33,15 +32,7 @@ class MimallocConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    @property
-    def _cmake(self):
-        if not self._cmake_i:
-            self._cmake_i = CMake(self)
-            self._cmake_i.definitions["MI_BUILD_TESTS"] = False
-            self._cmake_i.definitions["MI_BUILD_SHARED"] = self.options.shared
-            self._cmake_i.definitions["MI_BUILD_STATIC"] = not self.options.shared
-            self._cmake_i.configure(build_folder=self._build_subfolder)
-        return self._cmake_i
+    _cmake = None
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -52,35 +43,99 @@ class MimallocConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.override
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "14")
         if self.options.shared:
             del self.options.fPIC
+        if self.settings.compiler == "Visual Studio":
+            if self.options.shared == True and "MT" in str(self.settings.compiler.runtime):
+                raise ConanInvalidConfiguration("Cannot use MT(d) runtime when building mimalloc as a shared library")
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        if self.settings.compiler == "Visual Studio":
+            self._cmake.generator = "NMake Makefiles"
+        self._cmake.definitions["CMAKE_BUILD_TYPE"] = self.settings.build_type
+        self._cmake.definitions["MI_BUILD_TESTS"] = False
+        self._cmake.definitions["MI_BUILD_SHARED"] = self.options.shared == True
+        self._cmake.definitions["MI_BUILD_STATIC"] = self.options.shared == False
+        self._cmake.definitions["MI_BUILD_OBJECT"] = self.options.shared == "object"
+        self._cmake.definitions["MI_SECURE"] = "ON" if self.options.secure else "OFF"  # Needs to be ON/OFF!
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
-        self._cmake.build()
+        if self.settings.compiler == "Visual Studio" and self.settings.arch == "x86":
+            tools.replace_path_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                       "mimalloc-redirect.lib", "mimalloc-redirect32.lib")
+        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+            cmake = self._configure_cmake()
+            cmake.build()
 
     def package(self):
-        self._cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", self._cmake_install_folder, "cmake"))
-
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+            cmake = self._configure_cmake()
+            cmake.install()
+
+        if self.settings.os == "Windows":
+            if self.options.shared == True or self.options.shared == "object":
+                if self.settings.arch == "x86_64":
+                    self.copy("mimalloc-redirect.dll", src=os.path.join(self._source_subfolder, "bin"), dst=self._install_prefix)
+                elif self.settings.arch == "x86":
+                    self.copy("mimalloc-redirect32.dll", src=os.path.join(self._source_subfolder, "bin"), dst=self._install_prefix)
+
+        tools.rmdir(os.path.join(self.package_folder, self._install_prefix, "cmake"))
+
+    @property
+    def _install_prefix(self):
+        version = tools.Version(self.version)
+        return os.path.join("lib", "{}-{}.{}".format(self.name, version.major, version.minor))
+
+    @property
+    def _obj_name(self):
+        name = "mimalloc"
+        if self.options.secure:
+            name += "-secure"
+        if self.settings.build_type not in ("Release", "RelWithDebInfo", "MinSizeRel"):
+            name += "-{}".format(str(self.settings.build_type))
+        return name
+
+    @property
+    def _lib_name(self):
+        name = "mimalloc"
+        if self.settings.os == "Windows":
+            if self.options.shared == False:
+                name += "-static"
+            if self.options.secure:
+                name += "-secure"
+            if self.settings.build_type not in ("Release", "RelWithDebInfo", "MinSizeRel"):
+                name += "-{}".format(str(self.settings.build_type))
+        return name
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.includedirs = [os.path.join("lib", self._cmake_install_folder, "include")]
-        self.cpp_info.libdirs = [os.path.join("lib", self._cmake_install_folder)]
-        objext = "obj" if self.settings.compiler == "Visual Studio" else "o"
-        self.cpp_info.exelinkflags = [
-            os.path.join(self.package_folder, "lib", self._cmake_install_folder, "mimalloc.{}".format(objext))]
-        self.cpp_info.sharedlinkflags = [
-            os.path.join(self.package_folder, "lib", self._cmake_install_folder, "mimalloc.{}".format(objext))]
+        self.cpp_info.includedirs = [os.path.join(self._install_prefix, "include")]
+        if self.options.shared == "object":
+            objext = "obj" if self.settings.os == "Windows" else "o"
+            obj_path = os.path.join(self.package_folder, self._install_prefix, "{}.{}".format(self._obj_name, objext))
+            self.cpp_info.exelinkflags = [obj_path]
+            self.cpp_info.sharedlinkflags = [obj_path]
+            self.cpp_info.libdirs = []
+            self.cpp_info.bindirs = []
+        else:
+            self.cpp_info.libs = [self._lib_name]
+            self.cpp_info.libdirs = [self._install_prefix]
+            self.cpp_info.bindirs = [self._install_prefix]
 
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
-        if not self.options.shared:
+        if self.options.shared == False or self.options.shared == "object":
             if self.settings.os == "Windows":
                 self.cpp_info.system_libs.extend(["psapi", "shell32", "user32", "bcrypt"])
             elif self.settings.os == "Linux":

--- a/recipes/mimalloc/all/test_package/CMakeLists.txt
+++ b/recipes/mimalloc/all/test_package/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 2.8.11)
-project(PackageTest LANGUAGES C)
+project(PackageTest C CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(test_package test_package.c)
-
 target_link_libraries(test_package ${CONAN_LIBS})
+
+add_executable(test_package_cpp test_package.cpp)
+target_link_libraries(test_package_cpp ${CONAN_LIBS})

--- a/recipes/mimalloc/all/test_package/conanfile.py
+++ b/recipes/mimalloc/all/test_package/conanfile.py
@@ -12,6 +12,9 @@ class MimallocTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self.settings, skip_x64_x86=True):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
+
+            test_package_cpp = os.path.join("bin", "test_package_cpp")
+            self.run(test_package_cpp, run_environment=True)

--- a/recipes/mimalloc/all/test_package/test_package.cpp
+++ b/recipes/mimalloc/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include "mimalloc-new-delete.h"
+#include "mimalloc.h"
+
+#include <iostream>
+
+int main() {
+    int *data = new int(1337);
+    delete data;
+
+    std::cout << "mimalloc version " << mi_version() << "\n";
+    mi_stats_print(0);
+    return 0;
+}


### PR DESCRIPTION
This patch makes it work on MSVC:
- Added a object option, in shared. Because shared/static and object can be used exclusive.
- Copy the mimalloc-redirect.dll library to the package
- fixes the names of the object and library
- fix the cmakelists for 32-bit builds on Windows

Tested on MSVC and mingw, not on Linux.